### PR TITLE
Support osx-arm64 platform

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,16 +8,16 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_numpy1.21python3.10.____cpythonpython_implcpython:
-        CONFIG: linux_64_numpy1.21python3.10.____cpythonpython_implcpython
+      linux_64_numpy1.22python3.10.____cpythonpython_implcpython:
+        CONFIG: linux_64_numpy1.22python3.10.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_numpy1.21python3.8.____cpythonpython_implcpython:
-        CONFIG: linux_64_numpy1.21python3.8.____cpythonpython_implcpython
+      linux_64_numpy1.22python3.8.____cpythonpython_implcpython:
+        CONFIG: linux_64_numpy1.22python3.8.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_numpy1.21python3.9.____cpythonpython_implcpython:
-        CONFIG: linux_64_numpy1.21python3.9.____cpythonpython_implcpython
+      linux_64_numpy1.22python3.9.____cpythonpython_implcpython:
+        CONFIG: linux_64_numpy1.22python3.9.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_numpy1.23python3.11.____cpythonpython_implcpython:
@@ -27,11 +27,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,17 +8,29 @@ jobs:
     vmImage: macOS-11
   strategy:
     matrix:
-      osx_64_numpy1.21python3.10.____cpythonpython_implcpython:
-        CONFIG: osx_64_numpy1.21python3.10.____cpythonpython_implcpython
+      osx_64_numpy1.22python3.10.____cpythonpython_implcpython:
+        CONFIG: osx_64_numpy1.22python3.10.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.21python3.8.____cpythonpython_implcpython:
-        CONFIG: osx_64_numpy1.21python3.8.____cpythonpython_implcpython
+      osx_64_numpy1.22python3.8.____cpythonpython_implcpython:
+        CONFIG: osx_64_numpy1.22python3.8.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.21python3.9.____cpythonpython_implcpython:
-        CONFIG: osx_64_numpy1.21python3.9.____cpythonpython_implcpython
+      osx_64_numpy1.22python3.9.____cpythonpython_implcpython:
+        CONFIG: osx_64_numpy1.22python3.9.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
       osx_64_numpy1.23python3.11.____cpythonpython_implcpython:
         CONFIG: osx_64_numpy1.23python3.11.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.22python3.10.____cpython:
+        CONFIG: osx_arm64_numpy1.22python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.22python3.8.____cpython:
+        CONFIG: osx_arm64_numpy1.22python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.22python3.9.____cpython:
+        CONFIG: osx_arm64_numpy1.22python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.23python3.11.____cpython:
+        CONFIG: osx_arm64_numpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,14 +8,14 @@ jobs:
     vmImage: windows-2022
   strategy:
     matrix:
-      win_64_numpy1.21python3.10.____cpythonpython_implcpython:
-        CONFIG: win_64_numpy1.21python3.10.____cpythonpython_implcpython
+      win_64_numpy1.22python3.10.____cpythonpython_implcpython:
+        CONFIG: win_64_numpy1.22python3.10.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-      win_64_numpy1.21python3.8.____cpythonpython_implcpython:
-        CONFIG: win_64_numpy1.21python3.8.____cpythonpython_implcpython
+      win_64_numpy1.22python3.8.____cpythonpython_implcpython:
+        CONFIG: win_64_numpy1.22python3.8.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-      win_64_numpy1.21python3.9.____cpythonpython_implcpython:
-        CONFIG: win_64_numpy1.21python3.9.____cpythonpython_implcpython
+      win_64_numpy1.22python3.9.____cpythonpython_implcpython:
+        CONFIG: win_64_numpy1.22python3.9.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
       win_64_numpy1.23python3.11.____cpythonpython_implcpython:
         CONFIG: win_64_numpy1.23python3.11.____cpythonpython_implcpython

--- a/.ci_support/linux_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -1,0 +1,28 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+numpy:
+- '1.22'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- linux-64
+zip_keys:
+- - python
+  - numpy
+  - python_impl

--- a/.ci_support/linux_64_numpy1.22python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.8.____cpythonpython_implcpython.yaml
@@ -1,27 +1,27 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '15'
+- '12'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-macos_machine:
-- x86_64-apple-darwin13.4.0
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
-- '1.21'
+- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 python_impl:
 - cpython
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -1,0 +1,28 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+numpy:
+- '1.22'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- linux-64
+zip_keys:
+- - python
+  - numpy
+  - python_impl

--- a/.ci_support/osx_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -1,27 +1,27 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
-cdt_name:
-- cos6
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
-- '1.21'
+- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.10.* *_cpython
 python_impl:
 - cpython
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/osx_64_numpy1.22python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.8.____cpythonpython_implcpython.yaml
@@ -1,17 +1,17 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
-cdt_name:
-- cos6
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
-- '1.21'
+- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -21,7 +21,7 @@ python:
 python_impl:
 - cpython
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/osx_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -11,13 +11,13 @@ channel_targets:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
-- '1.21'
+- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.9.* *_cpython
 python_impl:
 - cpython
 target_platform:

--- a/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
@@ -1,11 +1,17 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
 c_compiler:
-- vs2019
+- clang
+c_compiler_version:
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+macos_machine:
+- arm64-apple-darwin20.0.0
 numpy:
-- '1.21'
+- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -15,7 +21,7 @@ python:
 python_impl:
 - cpython
 target_platform:
-- win-64
+- osx-arm64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/osx_arm64_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.8.____cpython.yaml
@@ -1,0 +1,28 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '15'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '1.22'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- osx-arm64
+zip_keys:
+- - python
+  - numpy
+  - python_impl

--- a/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
@@ -1,0 +1,28 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '15'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '1.22'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- osx-arm64
+zip_keys:
+- - python
+  - numpy
+  - python_impl

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
@@ -1,21 +1,27 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
 c_compiler:
-- vs2019
+- clang
+c_compiler_version:
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+macos_machine:
+- arm64-apple-darwin20.0.0
 numpy:
-- '1.21'
+- '1.23'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.11.* *_cpython
 python_impl:
 - cpython
 target_platform:
-- win-64
+- osx-arm64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/win_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -5,13 +5,13 @@ channel_sources:
 channel_targets:
 - conda-forge main
 numpy:
-- '1.21'
+- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.10.* *_cpython
 python_impl:
 - cpython
 target_platform:

--- a/.ci_support/win_64_numpy1.22python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.8.____cpythonpython_implcpython.yaml
@@ -1,17 +1,11 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
-c_compiler_version:
-- '15'
+- vs2019
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
-- '1.21'
+- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -21,7 +15,7 @@ python:
 python_impl:
 - cpython
 target_platform:
-- osx-64
+- win-64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/win_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -1,27 +1,21 @@
 c_compiler:
-- gcc
-c_compiler_version:
-- '12'
-cdt_name:
-- cos6
+- vs2019
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
-- '1.21'
+- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.9.* *_cpython
 python_impl:
 - cpython
 target_platform:
-- linux-64
+- win-64
 zip_keys:
 - - python
   - numpy

--- a/README.md
+++ b/README.md
@@ -27,24 +27,24 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_numpy1.21python3.10.____cpythonpython_implcpython</td>
+              <td>linux_64_numpy1.22python3.10.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11425&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.10.____cpythonpython_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.10.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.21python3.8.____cpythonpython_implcpython</td>
+              <td>linux_64_numpy1.22python3.8.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11425&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.8.____cpythonpython_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.8.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.21python3.9.____cpythonpython_implcpython</td>
+              <td>linux_64_numpy1.22python3.9.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11425&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.9.____cpythonpython_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.9.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -55,24 +55,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.21python3.10.____cpythonpython_implcpython</td>
+              <td>osx_64_numpy1.22python3.10.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11425&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.10.____cpythonpython_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.10.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.21python3.8.____cpythonpython_implcpython</td>
+              <td>osx_64_numpy1.22python3.8.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11425&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.8.____cpythonpython_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.8.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.21python3.9.____cpythonpython_implcpython</td>
+              <td>osx_64_numpy1.22python3.9.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11425&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.9.____cpythonpython_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.9.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -83,24 +83,52 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.21python3.10.____cpythonpython_implcpython</td>
+              <td>osx_arm64_numpy1.22python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11425&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.10.____cpythonpython_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.22python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.21python3.8.____cpythonpython_implcpython</td>
+              <td>osx_arm64_numpy1.22python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11425&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.8.____cpythonpython_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.22python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.21python3.9.____cpythonpython_implcpython</td>
+              <td>osx_arm64_numpy1.22python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11425&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.9.____cpythonpython_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.22python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.23python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11425&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.23python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.22python3.10.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11425&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.22python3.10.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.22python3.8.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11425&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.22python3.8.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.22python3.9.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11425&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configspace-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.22python3.9.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,5 +4,7 @@ github:
   tooling_branch_name: main
 bot:
   inspection: update-grayskull
+build_platform:
+  osx_arm64: osx_64
 conda_build:
   pkg_format: '2'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 63f22faaa593cb7256feb41c26a355c53448bc5b13b5f2dcb976025c3dad4eaf
 
 build:
-  number: 0
+  number: 1
   skip: true  # [python_impl == 'pypy']
   script: {{ PYTHON }} -m pip install . -vv
 


### PR DESCRIPTION
The current build only creates a version for osx-64 (Intel) and lacks support for the ARM chips although ConfigSpace supports it.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

I went through conda-forge's documentation and I think the pull request should work, but I'm not 100% sure.
